### PR TITLE
added return value of  to add_slider() method.

### DIFF
--- a/src/CycloneSlider/Data.php
+++ b/src/CycloneSlider/Data.php
@@ -99,6 +99,9 @@ class CycloneSlider_Data {
             
             // Save slider settings
             $this->add_slider_settings( $slider_id, $slider_settings );
+
+	    //return the slider ID
+	    return $slider_id;
 			
         }
     }


### PR DESCRIPTION
Currently, the method does not return anything when called. This returns the $slider_id on success.
